### PR TITLE
Update to use Elasticsearch fitsheaders alias.

### DIFF
--- a/lcogt_awsarchiveaccess/lco_archive_utilities.py
+++ b/lcogt_awsarchiveaccess/lco_archive_utilities.py
@@ -146,7 +146,7 @@ def get_frames_by_identifiers(dayobs, site=None, cameratype=None, camera=None, m
         terms_filters.append ({'FILTER': filterlist})
 
     queries = []
-    records = make_elasticsearch('fitsheaders', query_filters, queries, exclusion_filters=None, es_url=es_url,
+    records = make_elasticsearch('lco-fitsheaders', query_filters, queries, exclusion_filters=None, es_url=es_url,
                                  range_filters=range_filters, prefix_filters=prefix_filters,
                                  terms_filters=terms_filters).scan()
     if records is None:


### PR DESCRIPTION
The LCO fitsheaders ES index now has an alias, lco-fitsheaders, which all client software should point to. This improves the sustainability of the index, namely when re-indexing to change the schema as necessary. Re-indexing requires the creation of a new index and a copy operation. When addressing an alias, this migration process will be transparent all client software using said alias. See https://www.lewuathe.com/how-to-reindex-elasticsearch.html for more details.

This change is safe to deploy now, as the alias has already been created. Without this change, ES queries will continue to work by addressing fitsheaders, but if a migration ever occurs, those queries will no longer work.